### PR TITLE
fix(streaming): extend CLI flag and JSON stream parsing fixes to CSV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v2.1.1] - 2025-11-12
+
+### 🐛 Bug Fixes (v2.1.1)
+
+- **CLI Streaming Logic**: Fixed a critical bug where the `--stream` flag was ignored by the `parse-json` command, causing it to incorrectly throw a `FileTooLarge` error instead of entering streaming mode. The orchestration logic in `parseJsonFromFile` has been updated to prioritize the stream flag over initial file size checks. **This fix has also been applied to `parseCsvFromFile` to ensure consistent streaming behavior for CSV files.**
+- **Flexible JSON Streaming**: The streaming JSON parser (`parseJsonStream`) has been updated to correctly handle streams of multiple, distinct JSON objects (e.g., NDJSON or concatenated objects) by using `stream-json`'s `streamValues` and `jsonStreaming: true` options. This resolves syntax errors when parsing large files that are not a single, self-contained JSON array.
+- **ESM Import Fix**: Corrected named import errors for `stream-chain` and `stream-json` by switching to default imports, resolving a `SyntaxError` when running in a pure ESM environment.
+
+---
+
 ## [v2.1.0] - 2025-11-12
 
 ### ✨ Features (v2.1.0)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 [![Node.js](https://img.shields.io/badge/node-%3E=18.0.0-brightgreen)](https://nodejs.org/)
 [![CI](https://github.com/nexicore-digitals/nexus-dsm-toolkit/actions/workflows/ci.yml/badge.svg)](https://github.com/nexicore-digitals/nexus-dsm-toolkit/actions/workflows/ci.yml)
 [![CodeQL](https://github.com/nexicore-digitals/nexus-dsm-toolkit/actions/workflows/codeql.yml/badge.svg)](https://github.com/nexicore-digitals/nexus-dsm-toolkit/actions/workflows/codeql.yml)
-[![Build Status](https://img.shields.io/github/actions/workflow/status/nexicore-digitals/nexus-dsm-toolkit/publish.yml?branch=release/v2.1.0)](https://github.com/nexicore-digitals/nexus-dsm-toolkit/actions/workflows/publish.yml)
 ![Modular DX](https://img.shields.io/badge/modular-DX-blue)
 ![Beginner Friendly](https://img.shields.io/badge/beginner-friendly-green)
 ![Nexi Inside](https://img.shields.io/badge/Nexi-AI-blue)

--- a/cli.ts
+++ b/cli.ts
@@ -215,11 +215,18 @@ async function main() {
             "parse-json <input>",
             "Parse a JSON file and log its metadata",
             (yargs) => {
-                return yargs.positional("input", {
-                    describe: "Path to the JSON file to parse",
-                    type: "string",
-                    demandOption: true,
-                });
+                return yargs
+                    .positional("input", {
+                        describe: "Path to the JSON file to parse",
+                        type: "string",
+                        demandOption: true,
+                    })
+                    .option("stream", {
+                        describe:
+                            "Stream the input file, bypassing the default size limit",
+                        type: "boolean",
+                        default: false,
+                    });
             },
             async (argv) => {
                 const spinner = ora(`Parsing JSON file: ${argv.input}`).start();

--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
     "name": "@nexicore/nexus-dsm",
-    "version": "2.1.0",
+    "version": "2.1.1",
     "description": "Modular toolkit for parsing, validating, and converting structured datasets (CSV ↔ JSON) with reviewer clarity.",
     "exports": {
         ".": "./mod.ts"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nexus-dsm",
-    "version": "2.1.0",
+    "version": "2.1.1",
     "description": "Modular toolkit for parsing, validating, and converting structured datasets (CSV ↔ JSON) with reviewer clarity.",
     "type": "module",
     "license": "MIT",
@@ -17,7 +17,7 @@
         "maintainer": "Owen • Nexicore Digital",
         "description": "Modular toolkit for parsing, validating, and converting structured datasets (CSV ↔ JSON) with reviewer clarity.",
         "license": "MIT",
-        "version": "2.1.0",
+        "version": "2.1.1",
         "bin": {
             "nexus-dsm": "./dist/cli.js"
         },

--- a/src/parsers/csv-parser-orchestration.ts
+++ b/src/parsers/csv-parser-orchestration.ts
@@ -14,6 +14,7 @@ import {
 } from "../../src/utils/file-analysis.js";
 import { sortCsvErrorsByPriority } from "../utils/csv-error-priority.js";
 import { createReadStream } from "fs";
+import path from "path";
 
 const MAX_SIZE_BYTES = 5 * 1024 * 1024; // 5MB (kept for consistency, but `analyzeFileMetadata` also uses it)
 
@@ -49,6 +50,15 @@ export async function parseCsvFromFile(
             success: false,
             detailedErrors: [csvEnvironmentError],
         };
+    }
+
+    // If streaming is explicitly requested, bypass the initial metadata analysis for size
+    // and go directly to the streaming parser.
+    if (options?.stream) {
+        const readStream = createReadStream(filePath, {
+            encoding: "utf8",
+        });
+        return parseCsvStream(readStream, path.basename(filePath));
     }
 
     const fileMetadata = await analyzeFileMetadata(filePath);

--- a/src/parsers/json-parser-orchestration.ts
+++ b/src/parsers/json-parser-orchestration.ts
@@ -19,6 +19,7 @@ import {
 } from "../../src/utils/file-analysis.js";
 import { createReadStream } from "fs";
 import { parseJsonStream } from "./json-stream-parser.js";
+import path from "path";
 
 const MAX_SIZE_BYTES = 50 * 1024 * 1024; // 50MB
 
@@ -43,6 +44,15 @@ export default async function parseJsonFromFile(
             success: false,
             detailedErrors: [jsonEnvironmentError],
         };
+    }
+
+    // If streaming is explicitly requested, bypass the initial metadata analysis for size
+    // and go directly to the streaming parser.
+    if (options?.stream) {
+        const readStream = createReadStream(filePath, {
+            encoding: "utf8",
+        });
+        return parseJsonStream(readStream, path.basename(filePath));
     }
 
     const customErrors: SpecificJsonError[] = [];


### PR DESCRIPTION
This commit addresses several critical bugs related to the file streaming functionality, extending the fixes previously applied to JSON parsing to also cover CSV.

-   **CLI `--stream` Flag for CSV**: The orchestration logic in `parseCsvFromFile` has been updated to correctly prioritize the `--stream` flag, allowing it to bypass initial file size checks and immediately use stream-based parsing for CSV files. This mirrors the fix previously applied to JSON parsing.
-   **CLI `--stream` Flag for JSON**: The `parse-json` command was missing the `--stream` option definition, causing the flag to be ignored and resulting in premature `FileTooLarge` errors. The orchestration logic in `parseJsonFromFile` has been updated to ensure the stream flag bypasses initial size checks.
-   **Flexible JSON Streaming**: The `parseJsonStream` function has been refactored to use `streamValues` instead of `streamArray`. This allows it to correctly parse streams containing multiple top-level JSON objects (like NDJSON), which previously caused syntax errors.
-   **ESM/CJS Interop**: Corrected `SyntaxError` issues with `stream-chain` and `stream-json` by switching from named to default imports, ensuring compatibility in ESM-first Node.js environments.